### PR TITLE
Fixes for Altitude issues since plane 4.5

### DIFF
--- a/MavLink_FrSkySPort/FrSkySPortTelemetry.ino
+++ b/MavLink_FrSkySPort/FrSkySPortTelemetry.ino
@@ -545,14 +545,17 @@ void FrSkySportTelemetry_A3A4() {
 void FrSkySportTelemetry_VARIO() {
   #ifdef DEBUG_FrSkySportTelemetry_VARIO
     debugSerial.print(millis());
-    debugSerial.print("\tCurrent altitude: ");
-    debugSerial.print(ap_bar_altitude / 100.0);
+//    debugSerial.print("\tCurrent altitude: ");
+//    debugSerial.print(ap_bar_altitude / 100.0);
+    debugSerial.print("\tCurrent home altitude: ");
+    debugSerial.print(ap_relative_alt / 100.0);
     debugSerial.print("m\tCurrent climb rate in meters/second: ");
     debugSerial.print(ap_climb_rate);
     debugSerial.print("m/s");
     debugSerial.println();
   #endif
-  vario.setData(ap_bar_altitude,  // Current altitude (MSL), in meters
+    //vario.setData(ap_bar_altitude,  // Current altitude (MSL), in meters
+    vario.setData(ap_relative_alt,    // Current home location altitude, in centimeters
                 ap_climb_rate);   // Current climb rate in meters/second
 }
 

--- a/MavLink_FrSkySPort/FrSkySPortTelemetry.ino
+++ b/MavLink_FrSkySPort/FrSkySPortTelemetry.ino
@@ -43,7 +43,6 @@
 #include "Time.h"
 #include "FrSkySportSensor.h"
 #include "FrSkySportSensorFas.h"
-#include "FrSkySportSensorAss.h"
 #include "FrSkySportSensorFuel.h"
 #include "FrSkySportSensorFlvss.h"
 #include "FrSkySportSensorGps.h"
@@ -69,7 +68,6 @@ FrSkySportSensorFuel fuel;                             // Create FUEL sensor wit
     FrSkySportSensorFlvss flvss2(FrSkySportSensor::ID15);  // Create FLVSS sensor with given ID
   #endif
 #endif
-FrSkySportSensorAss ass;                               // Create ASS sensor with default ID
 FrSkySportSensorGps gps;                               // Create GPS sensor with default ID
 FrSkySportSensorRpm rpm;                               // Create RPM sensor with default ID
 FrSkySportSensorAcc acc;                               // Create ACC sensor with default ID
@@ -118,22 +116,22 @@ void FrSkySPort_Init()
   #if defined USE_SINGLE_CELL_MONITOR || defined USE_FLVSS_FAKE_SENSOR_DATA
     #if (MAXCELLS <= 6)
       #ifdef USE_FAS_SENSOR_INSTEAD_OF_APM_DATA
-        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &flvss1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &flvss1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
       #else
-        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &flvss1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &flvss1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
       #endif
     #else
       #ifdef USE_FAS_SENSOR_INSTEAD_OF_APM_DATA
-        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &flvss1, &flvss2, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &flvss1, &flvss2, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
       #else
-        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &flvss1, &flvss2, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+        telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &flvss1, &flvss2, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
       #endif
     #endif
   #else
     #ifdef USE_FAS_SENSOR_INSTEAD_OF_APM_DATA
-      telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+      telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
     #else
-      telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &gps, &sp2uart, &rpm, &vario, &fuel, &acc, &ass);
+      telemetry.begin(FrSkySportSingleWireSerial::SERIAL_1, &fas, &gps, &sp2uart, &rpm, &vario, &fuel, &acc);
     #endif
   #endif
 }
@@ -159,12 +157,6 @@ void FrSkySPort_Process()
    * *****************************************************
    */
   FrSkySportTelemetry_FAS();
-/*
-   * *****************************************************
-   * *** Set airspeed sensor (ASS) data                ***
-   * *****************************************************
-   */
-  FrSkySportTelemetry_ASS();
 
   /*
    * *****************************************************
@@ -395,11 +387,25 @@ void FrSkySportTelemetry_FLVSS() {
  * *******************************************************
  */
 void FrSkySportTelemetry_GPS() {
+  if(ap_fixtype>=3)
+  {
+    /*
+    if(ap_longitude < 0)
+      longitude=((abs(ap_longitude)/100)*6);//  | 0xC0000000;
+    else
+      longitude=((abs(ap_longitude)/100)*6);//  | 0x80000000;
+
+      if(ap_latitude < 0 )
+      latitude=((abs(ap_latitude)/100)*6);// | 0x40000000;
+    else
+      latitude=((abs(ap_latitude)/100)*6);
+    */
     gps.setData(ap_latitude / 1E7, ap_longitude / 1E7,    // Latitude and longitude in degrees decimal (positive for N/E, negative for S/W)
-        ap_gps_altitude / 10.0,                     // Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.
-        ap_gps_speed * 10.0,                        // GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX
-        ap_heading ,                                // Heading, in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX
-        ap_gps_hdop);                               // GPS HDOP horizontal dilution of position in cm (m*100)
+              ap_gps_altitude / 10.0,         // Altitude (AMSL, NOT WGS84), in meters * 1000 (positive for up). Note that virtually all GPS modules provide the AMSL altitude in addition to the WGS84 altitude.
+              ap_gps_speed * 10.0,// / 100.0,            // GPS ground speed (m/s * 100). If unknown, set to: UINT16_MAX
+              ap_heading ,                     // Heading, in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX
+              ap_gps_hdop);                   // GPS HDOP horizontal dilution of position in cm (m*100)
+//              ap_cog,                         // Course over ground (NOT heading, but direction of movement) in degrees * 100, 0.0..359.99 degrees. If unknown, set to: UINT16_MAX
 
     #ifdef DEBUG_FrSkySportTelemetry_GPS
       if (millis() > GPS_debug_time) {
@@ -449,6 +455,7 @@ void FrSkySportTelemetry_GPS() {
         GPS_debug_time = millis() + 500;
       }
     #endif
+  }
 }
 
 /*
@@ -595,14 +602,7 @@ void FrSkySportTelemetry_FUEL() {
   }
 }
 
-/*
- * *****************************************************
- * *** Set Airspeed sensor data                      ***
- * *****************************************************
- */
-void FrSkySportTelemetry_ASS() {
-  ass.setData(ap_airspeed);
-}
+
 /*
  * *****************************************************
  * *** Helper function "queue buffer" to queue       ***

--- a/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
+++ b/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
@@ -270,7 +270,7 @@ uint16_t    ap_chan_raw[18]       = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};  // R
  * *** Message #74  VFR_HUD                            ***
  * *******************************************************
  */
-//int32_t     ap_airspeed           = 0;    // Current airspeed in m/s
+int32_t     ap_airspeed           = 0;    // Current airspeed in m/s
 uint32_t    ap_groundspeed        = 0;    // Current ground speed in m/s
 uint32_t    ap_heading            = 0;    // Current heading in degrees, in compass units (0..360, 0=north)
 uint16_t    ap_throttle           = 0;    // Current throttle setting in integer percent, 0 to 100

--- a/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
+++ b/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
@@ -270,7 +270,7 @@ uint16_t    ap_chan_raw[18]       = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};  // R
  * *** Message #74  VFR_HUD                            ***
  * *******************************************************
  */
-int32_t     ap_airspeed           = 0;    // Current airspeed in m/s
+//int32_t     ap_airspeed           = 0;    // Current airspeed in m/s
 uint32_t    ap_groundspeed        = 0;    // Current ground speed in m/s
 uint32_t    ap_heading            = 0;    // Current heading in degrees, in compass units (0..360, 0=north)
 uint16_t    ap_throttle           = 0;    // Current throttle setting in integer percent, 0 to 100

--- a/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
+++ b/MavLink_FrSkySPort/MavLink_FrSkySPort.ino
@@ -150,6 +150,7 @@
 //#define DEBUG_APM_RAW_IMU                   // MSG #27  - not used -> use: DEBUG_APM_ACC
 //#define DEBUG_APM_ACC                       // Debug Accelerometer
 //#define DEBUG_APM_ATTITUDE                  // MSG #30
+//#define DEBUG_APM_GLOBAL_POSITION_INT       // MSG #33
 //#define DEBUG_APM_GLOBAL_POSITION_INT_COV   // MSG #63  - planned - currently not implemented - not supported by APM
 //#define DEBUG_APM_RC_CHANNELS               // MSG #65
 //#define DEBUG_APM_VFR_HUD                   // MSG #74
@@ -245,6 +246,14 @@ uint32_t    ap_yaw_angle          = 0;      // Yaw angle (rad)
 uint32_t    ap_roll_speed         = 0;      // Roll angular speed (rad/s)
 uint32_t    ap_pitch_speed        = 0;      // Pitch angular speed (rad/s)
 uint32_t    ap_yaw_speed          = 0;      // Yaw angular speed (rad/s)
+
+/*
+ * *******************************************************
+ * *** Message #33  GLOBAL_POSITION_INT                ***
+ * *** Needed for relative altitude                    ***
+ * *******************************************************
+ */
+int32_t      ap_relative_alt      = 0;      // Relative Altitude (cm)
 
 /*
  * *******************************************************

--- a/MavLink_FrSkySPort/Mavlink.ino
+++ b/MavLink_FrSkySPort/Mavlink.ino
@@ -462,6 +462,7 @@ void _MavLink_receive() {
          */
         case MAVLINK_MSG_ID_VFR_HUD:
           ap_groundspeed = mavlink_msg_vfr_hud_get_groundspeed(&msg);      // 100 = 1m/s
+          ap_airspeed = mavlink_msg_vfr_hud_get_airspeed(&msg);            // 100 = 1m/s
           ap_heading = mavlink_msg_vfr_hud_get_heading(&msg);              // 100 = 100 deg
           ap_throttle = mavlink_msg_vfr_hud_get_throttle(&msg);            //  100 = 100%
           ap_bar_altitude = mavlink_msg_vfr_hud_get_alt(&msg) * 100;       //  m

--- a/MavLink_FrSkySPort/Mavlink.ino
+++ b/MavLink_FrSkySPort/Mavlink.ino
@@ -374,6 +374,20 @@ void _MavLink_receive() {
           break;
         /*
          * *****************************************************
+         * *** MAVLINK Message #33 - GLOBAL_POSITION_INT     ***
+         * *****************************************************
+         */
+        case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:   // 33
+          ap_relative_alt = mavlink_msg_global_position_int_get_relative_alt(&msg)*0.1;
+          #ifdef DEBUG_APM_GLOBAL_POSITION_INT
+            debugSerial.print(millis());
+            debugSerial.print("\tMAVLINK_MSG_ID_GLOBAL_POSITION_INT: relative_altitude: ");
+            debugSerial.print(ap_relative_alt);
+            debugSerial.println();
+          #endif
+          break;
+        /*
+         * *****************************************************
          * *** MAVLINK Message #63 - GLOBAL_POSITION_INT_COV ***
          * *****************************************************
          */

--- a/MavLink_FrSkySPort/Mavlink.ino
+++ b/MavLink_FrSkySPort/Mavlink.ino
@@ -462,7 +462,6 @@ void _MavLink_receive() {
          */
         case MAVLINK_MSG_ID_VFR_HUD:
           ap_groundspeed = mavlink_msg_vfr_hud_get_groundspeed(&msg);      // 100 = 1m/s
-          ap_airspeed = mavlink_msg_vfr_hud_get_airspeed(&msg);            // 100 = 1m/s
           ap_heading = mavlink_msg_vfr_hud_get_heading(&msg);              // 100 = 100 deg
           ap_throttle = mavlink_msg_vfr_hud_get_throttle(&msg);            //  100 = 100%
           ap_bar_altitude = mavlink_msg_vfr_hud_get_alt(&msg) * 100;       //  m


### PR DESCRIPTION
Since the Plane 4.5 (and newer) firmware was released, ardupilot seems to derive the mavlink altitude values differently. This resulted in the Alt value on LUA screen using MSL Alt rather than Home Alt. Have determined however that a different mavlink message is available which still provides the home Alt value correctly, and this message also exists in earlier APM firmware, so this change still provides working Alt reading in ap 3.3 (haven't tested earlier versions, as I don't have these any more on any model). So this change introduces 'ap_relative_alt' into the code, replacing 'ap_bar_altitude'.
For more info about what was broken in ap Plane 3.5 - the ap_relative_alt message, when the craft was powered (prior to GPS fix) would display correctly the Alt value based on barometer, but then once GPS fix was obtained, this would change to be the MSL Altitude + relative alt from home position - so it would give us MSL altitude of our craft instead of maintaining Home Altitude. Given that the LUA screen has always been designed to show home Alt, this represented a significant and unwanted change, so this fix was established.
