### PR TITLE
fix for main.lua memory issues

### DIFF
--- a/Lua_Telemetry/DisplayApmPosition/SCRIPTS/TELEMETRY/main.lua
+++ b/Lua_Telemetry/DisplayApmPosition/SCRIPTS/TELEMETRY/main.lua
@@ -79,10 +79,10 @@
 	local battWhmax = 0
 	local whconsumed = 0
 	local batteryreachmaxWH = 0
+  local isotx22 = false
 
 	-- Temporary text attribute
 	local FORCE = 0x02 -- draw ??? line or rectangle
-  local RIGHT = 8 -- required so that number alignment option for OTx 2.2 also works in 2.1
 	local X1 = 0
 	local Y1 = 0
 	local X2 = 0
@@ -159,6 +159,12 @@
 		{3, 5, 0, -3},
 		{4, 5, 0, -4}
 	}
+
+-- OpenTx 2.2 checker function
+local function is22()
+  local ver, radio, maj, minor, rev = getVersion()
+  if maj == 2 and minor == 2 then isotx22 = true end
+end
 
 -- Telemetry helper function
   local function getTelemetryId(name)
@@ -272,7 +278,11 @@
 		for j=21, 61, 4 do
 			lcd.drawPoint(167+22, j)
 		end
-		lcd.drawNumber(189, 57,hypdist*gAlt_multi, RIGHT+SMLSIZE)
+    if isotx22 then
+      lcd.drawNumber(189, 57,hypdist*gAlt_multi, SMLSIZE+RIGHT)
+    else
+      lcd.drawNumber(189, 57,hypdist*gAlt_multi, SMLSIZE)
+    end
 		lcd.drawText(lcd.getLastPos(), 57, gAlt_units, SMLSIZE)
 	end
 
@@ -344,7 +354,11 @@
 		lcd.drawNumber(4,10,getValue("VFAS")*10,MIDSIZE+PREC1+LEFT)
 		lcd.drawText(lcd.getLastPos(),14,"V",0)
 
-		lcd.drawNumber(61,10,getValue("Cmin")*100,MIDSIZE+PREC2+RIGHT)
+    if isotx22 then
+      lcd.drawNumber(61,10,getValue("Cmin")*100,MIDSIZE+PREC2+RIGHT)
+    else
+      lcd.drawNumber(61,10,getValue("Cmin")*100,MIDSIZE+PREC2)
+    end
 		xposCons=lcd.getLastPos()
 		lcd.drawText(xposCons,9,"c-",SMLSIZE)
 		lcd.drawText(xposCons,15,"min",SMLSIZE)
@@ -352,7 +366,11 @@
 		lcd.drawNumber(4,24,getValue("Curr")*10,MIDSIZE+PREC1+LEFT)
 		lcd.drawText(lcd.getLastPos(),28,"A",0)
 
-		lcd.drawNumber(66,24,consumption + (consumption*gOffsetmah/100),MIDSIZE+RIGHT)
+    if isotx22 then
+      lcd.drawNumber(66,24,consumption + (consumption*gOffsetmah/100),MIDSIZE+RIGHT)
+    else
+      lcd.drawNumber(66,24,consumption + (consumption*gOffsetmah/100),MIDSIZE)
+    end
 		xposCons=lcd.getLastPos()
 		lcd.drawText(xposCons,24,"m",SMLSIZE)
 		lcd.drawText(xposCons,29,"Ah",SMLSIZE)
@@ -360,7 +378,11 @@
 		lcd.drawNumber(1,38,getValue("Watt"),MIDSIZE+LEFT)
 		lcd.drawText(lcd.getLastPos(),42,"W",0)
 
-		lcd.drawNumber(65,43,( watthours + ( watthours*gOffsetwatth/100) )*10,SMLSIZE+PREC1+RIGHT)
+    if isotx22 then
+      lcd.drawNumber(65,43,( watthours + ( watthours*gOffsetwatth/100) )*10,SMLSIZE+PREC1+RIGHT)
+    else
+      lcd.drawNumber(65,43,( watthours + ( watthours*gOffsetwatth/100) )*10,SMLSIZE+PREC1)
+    end
 		lcd.drawText(lcd.getLastPos(),43,"Wh",SMLSIZE)
 
 		--Armed time
@@ -368,7 +390,11 @@
 		lcd.drawText(1,56,"ArmT",SMLSIZE)
 		lcd.drawTimer(lcd.getLastPos()+2,56,model.getTimer(0).value,SMLSIZE)
 		--Model Runtime
-		lcd.drawNumber(71,56,model.getTimer(1).value/360,SMLSIZE+PREC1+RIGHT)
+    if isotx22 then
+      lcd.drawNumber(71,56,model.getTimer(1).value/360,SMLSIZE+PREC1+RIGHT)
+    else
+      lcd.drawNumber(71,56,model.getTimer(1).value/360,SMLSIZE+PREC1)
+    end
 		lcd.drawText(lcd.getLastPos(),56,"h",SMLSIZE)
 
 	end
@@ -488,6 +514,7 @@
 --Init
 	local function init()
 		checkGlobals()
+    is22()
 	end
 
 --Background


### PR DESCRIPTION
memory issues running original main.lua on OpenTx 2.1.9 - this fix allows it to run but still very tight on memory, and in some models I am having to not configure celing.lua to reduce the memory footprint to allow this telemetry script to run.